### PR TITLE
Release 2026.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ version=2026.4-SNAPSHOT
 #
 # main dependencies
 #
-hivemq.extension.sdk.version=4.28.0
+hivemq.extension.sdk.version=4.48.1
 metrics.version=4.2.5
 #
 # plugins


### PR DESCRIPTION
**card**: https://linear.app/hivemq/issue/EDG-94/hivemq-edge-20263-release

**Problem**                                                                                                                                                                                                                                                                                                           
                                                            
  Jenkins release build #137 for HiveMQ Edge 2026.3 failed because the ReleaseJenkinsfile COMPONENTS list was out of sync with the GitHub Actions prepare-release workflow. Three repositories (hivemq-data-hub, hivemq-extension-sdk, hivemq-edge-test) had no 2026.3 tag but Jenkins tried to clone them at that  
  ref.                                                      

**Root causes:**
  - hivemq-data-hub was removed as a local dependency (consumed as Maven artifact) but never removed from Jenkins COMPONENTS
  - hivemq-extension-sdk and hivemq-edge-test were checked out with register: false in the workflow, so they never received release branches or tags
  - hivemq-mtconnect-protocol has its own independent version lifecycle (1.0.0) but was being version-bumped alongside Edge releases
  - The hivemq-extension-sdk was included via includeBuild, silently overriding declared Maven versions with whatever happened to be on master at build time — making releases non-reproducible and causing published SDK artifacts to declare stale transitive dependencies (4.28.0 vs actual ~4.49.0-SNAPSHOT)

**Changes**

**Pin hivemq-extension-sdk to Maven Central 4.48.1 and remove includeBuild**
  - Remove the conditional includeBuild("../../hivemq-extension-sdk") from hivemq-edge/hivemq-edge/settings.gradle.kts
  - Update version pins in hivemq-edge/gradle/libs.versions.toml (4.43.0 → 4.48.1), hivemq-edge-extension-sdk/gradle.properties (4.28.0 → 4.48.1), hivemq-edge-adapter-sdk/gradle.properties (4.28.0 → 4.48.1), and hivemq-edge-test/gradle/libs.versions.toml (add explicit 4.48.1)

**Start tagging hivemq-edge-test with releases**
  - Create gradle.properties with current version, apply the edge-version-updater plugin, and add it to the updateAllVersions task
  - Register it in both _update-master.yaml and _prepare-release-branch.yaml workflows
  - Add a release step in _create-releases.yaml

**Stop branching hivemq-mtconnect-protocol and hivemq-extension-sdk in the workflow**
  - Remove their checkout steps from _update-master.yaml and _prepare-release-branch.yaml

**Align Jenkins with the workflow**
  - Remove hivemq-data-hub and hivemq-extension-sdk from COMPONENTS
  - Add hivemq-edge-test to COMPONENTS
  - Update release template to match

  
**Verification**
  - hivemq-extension-sdk:4.48.1 resolves from Maven Central (confirmed via ./gradlew dependencies)
  - hivemq-edge compileJava succeeds
  - hivemq-edge-test:updateVersion appears in the updateAllVersions task graph