### PR TITLE
PLT-524: Align CompositeJenkinsfile with hivemq-edge

### DIFF
--- a/CompositeJenkinsfile
+++ b/CompositeJenkinsfile
@@ -26,7 +26,6 @@ pipeline {
                             }
                         } finally {
                             cleanWs()
-                            build job: multiBranchJobPath, wait: false
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Aligns `CompositeJenkinsfile` with the version in `hivemq-edge` by removing the extra `build job: multiBranchJobPath, wait: false` call that ran after `cleanWs()` in the fallback path.

Linear: [PLT-524](https://linear.app/hivemq/issue/PLT-524/add-compositejenkinsfile-to-hivemq-edge-sdk-and-module-repos)

## Test plan
- [ ] Push to a feature branch; verify the corresponding `hivemq-edge-composite` branch job is triggered (or created on first push).